### PR TITLE
Reflect correct total GP balance

### DIFF
--- a/content/xips/xip-18.mdoc
+++ b/content/xips/xip-18.mdoc
@@ -19,7 +19,7 @@ Infinex is currently deployed on Base in closed alpha. With the imminent launch 
 
 The aim of the campaign is to efficiently allocate liquidity to the most valuable users, whilst also providing all users the chance to be granted access to Infinex. Users who participate in STW will also earn Governance Points in the process.
 
-This campaign will last 30 days, and distribute a total of 377,815,424 GP, resulting in a total supply of 465 million GP. Once STW begins, users will be able to create Infinex accounts and deposit USDC across six chains. Once a user's deposit has been processed, they will be able to stake their deposit for GP, with withdrawals disabled until the end of the campaign.
+This campaign will last 30 days, and distribute a total of 377,815,424 GP, resulting in a total supply of 500 million GP. Once STW begins, users will be able to create Infinex accounts and deposit USDC across six chains. Once a user's deposit has been processed, they will be able to stake their deposit for GP, with withdrawals disabled until the end of the campaign.
 
 Users are required to "claim" their GP for them to be reflected onchain. Once a user claims their GP, they will be placed into a waitlist (sorted by GP), with batches of users being granted access to the trading app as liquidity becomes available. The process in which people are granted access to the platform is controlled by The Council.
 


### PR DESCRIPTION
XIP-18 did not account the 45MIL GP from XIP-15, which was approved while this XIP was in voting,  this edit fixes this.